### PR TITLE
Bugfix/decimal rule key to location

### DIFF
--- a/src/clj/orb/cell.clj
+++ b/src/clj/orb/cell.clj
@@ -171,6 +171,10 @@
         states-vec (into [] states)]
     (into (subvec states-vec 0 4) (subvec states-vec (inc 4)))))
 
+(defn east-west-neighbor-states
+  [states]
+  [(nth states 3) (nth states 5)])
+
 (defn self-ref-rule-factory
   [neighbor-states-filter]
   (fn [neighbor-states world]

--- a/src/clj/orb/cell.clj
+++ b/src/clj/orb/cell.clj
@@ -179,6 +179,8 @@
   [states]
   [(nth states 1) (nth states 7)])
 
+;; Maps rule key (index) to cells grid location ([x y]). 
+;;
 ;; Index into rows data structure.  2D rows list must be 'unwrapped', in order to index into it
 ;; using rule-key.  Returns an [x y] location.
 (defn rule-key-location 

--- a/src/clj/orb/cell.clj
+++ b/src/clj/orb/cell.clj
@@ -182,10 +182,18 @@
 ;; Maps rule key (index) to cells grid location ([x y]). 
 ;;
 ;; Index into rows data structure.  2D rows list must be 'unwrapped', in order to index into it
-;; using rule-key.  Returns an [x y] location.
-(defn rule-key-location 
+;; using rule-key.  Unwrapps 'column-wise' (counts down entire first column, proceeds to second..). 
+;; Returns a [col row] location.
+(defn decimal-rule-key-to-location 
   [rule-key dimensions]
-  [(quot rule-key (first dimensions)) (mod rule-key (first dimensions))])
+  (let [col (quot rule-key (second dimensions))
+        row (mod rule-key (second dimensions))]
+    [col row]))
+
+(defn location-to-state
+  [world location]
+  (let [cells (get world :cells)]
+    (get cells location)))
 
 (defn self-ref-rule-factory
   [neighbor-states-filter]
@@ -195,35 +203,36 @@
           states-filtered (neighbor-states-filter neighbor-states)
         ;; Converts neigboring states binary str to decimal index, for use as rule key.
           rule-key (binary->number states-filtered)
-          cells (get world :cells)
-          location (rule-key-location rule-key dimensions)]
-      (get cells location))))
+          location (decimal-rule-key-to-location rule-key dimensions)]
+      (location-to-state world location))))
 
 (defn -main
   []
   (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
-        dimensions [16 16]
+        cols 32
+        rows 16
+        dimensions [cols rows]
         states [0 1]
-        world-init-state (make-world dimensions states (seed-random-state states))
+        ;; world-init-state (make-world dimensions states (seed-random-state states))
+        world-init-state (make-world dimensions states (fn [location] (if (#{[0 9] [3 3] [4 3]} location) 1 0)))
         ;; Number of generations to render.
-        generations 10
+        generations 1
         ;; Generate a rule function, using all neighbors
-        all-neighbors-self-ref-rule (self-ref-rule-factory all-neighbors-states)
-        world-final-state (reduce (fn [world-current-state generation]
-                                   (let [world-next-state (update-world world-current-state all-neighbors-self-ref-rule)]
-                                     (println)
-                                     (println (str "***Generation: " generation))
-                                     (println)
-                                     (print-states world-next-state)
-                                     world-next-state))
-                            world-init-state
-                            ;; Generations collection to reduce.
-                            (range generations))]
+        all-neighbors-self-ref-rule (self-ref-rule-factory identity)]
         
-    (println)
-    (println "***Finished***")
-    (println)
-    (print-states world-final-state)))
+    (println "***Init***")
+    (print-states world-init-state)
+    (reduce (fn [world-current-state generation]
+              (let [world-next-state (update-world world-current-state all-neighbors-self-ref-rule)]
+                (println)
+                (println (str "***Generation: " generation))
+                (println)
+                (print-states world-next-state)
+                world-next-state))
+            world-init-state
+                            ;; Generations collection to reduce.
+            (range generations))
+    ))
 
 
 

--- a/src/clj/orb/cell.clj
+++ b/src/clj/orb/cell.clj
@@ -175,6 +175,16 @@
   [states]
   [(nth states 3) (nth states 5)])
 
+(defn north-south-neighbor-states
+  [states]
+  [(nth states 1) (nth states 7)])
+
+;; Index into rows data structure.  2D rows list must be 'unwrapped', in order to index into it
+;; using rule-key.  Returns an [x y] location.
+(defn rule-key-location 
+  [rule-key dimensions]
+  [(quot rule-key (first dimensions)) (mod rule-key (first dimensions))])
+
 (defn self-ref-rule-factory
   [neighbor-states-filter]
   (fn [neighbor-states world]
@@ -184,10 +194,8 @@
         ;; Converts neigboring states binary str to decimal index, for use as rule key.
           rule-key (binary->number states-filtered)
           cells (get world :cells)
-        ;; Index into rows data structure.  2D rows list must be 'unwrapped', in order to index into it
-        ;; using rule-key.
-          rule-key-location [(quot rule-key (first dimensions)) (mod rule-key (first dimensions))]]
-      (get cells rule-key-location))))
+          location (rule-key-location rule-key dimensions)]
+      (get cells location))))
 
 (defn -main
   []

--- a/test/orb/cell_test.clj
+++ b/test/orb/cell_test.clj
@@ -3,7 +3,7 @@
             [orb.cell :as cell]))
 
 (deftest generate-rows-test
-  (testing "Generates list of rows."
+  (testing "Generates list of rows.  Each row location is stored as [col row]."
     (let [rows (cell/generate-rows [4 4])]
       (is (= rows '(([0 0] [1 0] [2 0] [3 0]) 
                     ([0 1] [1 1] [2 1] [3 1])
@@ -84,71 +84,78 @@
 
 ((deftest north-south-neighbors-states-test
    (testing "Filters to N and S neightbors."
-     (is (= [1 1] (cell/north-south-neighbor-states [0 1 0 0 0 0 0 1 0]))))))
+     (is (= [1 1] (cell/north-south-neighbor-states [0 1 0 
+                                                     0 0 0 
+                                                     0 1 0]))))))
 
 ((deftest rule-key-location-test-1
    (testing "Maps rule key (index) to cells grid location ([x y])"
-     (is (= [1 2] (cell/rule-key-location 5 [3 3]))))))
+     (is (= [1 2] (cell/decimal-rule-key-to-location 5 [3 3]))))))
 
 
 ((deftest rule-key-location-test-2
    (testing "Maps rule key (index) to cells grid location ([x y])"
-     (is (= [0 0] (cell/rule-key-location 0 [3 3]))))))
+     (is (= [0 0] (cell/decimal-rule-key-to-location 0 [3 3]))))))
 
-;; ((deftest self-ref-rule-east-west-neighbors-states-test-case-1
-;;    (testing "Filters to all neighbors (removes center, which is being updated)."
-;;      (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
+
+((deftest location-to-state-0-0
+   (testing "Location is mapped to the correct state."
+     (let [dimensions [2 2]
+           states [0 1]
+           world-state-init [[1 1]
+                             [0 0]]
+           world (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
+           ;; Generate a rule function, using only east and west neighbors
+           state (cell/location-to-state world [0 0])]
+      ;;  (println world-next-state)
+       (is (= state 1))))))
+
+
+((deftest location-to-state-0-1
+   (testing "Location is mapped to the correct state."
+     (let [dimensions [2 2]
+           states [0 1]
+           world-state-init [[1 1]
+                             [0 0]]
+           world (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
+           ;; Generate a rule function, using only east and west neighbors
+           state (cell/location-to-state world [0 1])] ;; [col row]
+       (is (= state 0))))))
+
+((deftest location-to-state-1-0
+   (testing "Location is mapped to the correct state."
+     (let [dimensions [2 2]
+           states [0 1]
+           world-state-init [[1 1]
+                             [0 0]]
+           world (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
+           ;; Generate a rule function, using only east and west neighbors
+           state (cell/location-to-state world [1 0])] ;; [col row]
+       (is (= state 1))))))
+
+
+((deftest location-to-state-1-1
+   (testing "Location is mapped to the correct state."
+     (let [dimensions [2 2]
+           states [0 1]
+           world-state-init [[1 1]
+                             [0 0]]
+           world (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
+           ;; Generate a rule function, using only east and west neighbors
+           state (cell/location-to-state world [1 1])] ;; [col row]
+       (is (= state 0))))))
+
+;; ((deftest self-ref-rule-north-south-neighbors-states-test-case-1
+;;    (testing "Updates world state to next generation correctly."
+;;      (let [;; Generate a 4 cell world to represent all values of 2 bit string (from N and S neighbor states) .
 ;;            dimensions [2 2]
 ;;            states [0 1]
 ;;            world-state-init [[1 0]
 ;;                              [0 1]]
 ;;            world-init (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
 ;;            ;; Generate a rule function, using only east and west neighbors
-;;            rule (cell/self-ref-rule-factory cell/east-west-neighbor-states)
+;;            rule (cell/self-ref-rule-factory cell/north-south-neighbor-states)
 ;;            world-next-state (cell/update-world world-init rule)]
 ;;       ;;  (println world-next-state)
 ;;        (is (= (vals (get world-next-state :cells)) '(1 1 
 ;;                                                      1 1)))))))
-
-;; ((deftest self-ref-rule-east-west-neighbors-states-test-case-2
-;;    (testing "Filters to all neighbors (removes center, which is being updated)."
-;;      (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
-;;            dimensions [2 2]
-;;            states [0 1]
-;;            world-state-init [[1 1]
-;;                              [0 0]]
-;;            world-init (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
-;;            ;; Generate a rule function, using only east and west neighbors
-;;            rule (cell/self-ref-rule-factory cell/east-west-neighbor-states)
-;;            world-next-state (cell/update-world world-init rule)]
-;;       ;;  (println world-next-state)
-;;        (is (= (vals (get world-next-state :cells)) '(0 0 1 1)))))))
-
-;; ((deftest self-ref-rule-north-south-neighbors-states-test-case-1
-;;    (testing "Filters to all neighbors (removes center, which is being updated)."
-;;      (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
-;;            dimensions [2 2]
-;;            states [0 1]
-;;            world-state-init [[1 0]
-;;                              [0 1]]
-;;            world-init (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
-;;            ;; Generate a rule function, using only east and west neighbors
-;;            rule (cell/self-ref-rule-factory cell/north-south-neighbor-states)
-;;            world-next-state (cell/update-world world-init rule)]
-;;       ;;  (println world-next-state)
-;;        (is (= (vals (get world-next-state :cells)) '(1 1
-;;                                                        1 1)))))))
-
-;; ((deftest self-ref-rule-east-west-neighbors-states-test-case-2
-;;    (testing "Filters to all neighbors (removes center, which is being updated)."
-;;      (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
-;;            dimensions [2 2]
-;;            states [0 1]
-;;            world-state-init [[1 1]
-;;                              [0 0]]
-;;            world-init (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
-;;            ;; Generate a rule function, using only east and west neighbors
-;;            rule (cell/self-ref-rule-factory cell/north-south-neighbor-states)
-;;            world-next-state (cell/update-world world-init rule)]
-;;       ;;  (println world-next-state)
-;;        (is (= (vals (get world-next-state :cells)) '(1 1 0 0)))))))

--- a/test/orb/cell_test.clj
+++ b/test/orb/cell_test.clj
@@ -79,20 +79,76 @@
         (is (= [0 0 0 1 1 0 0 0] (cell/all-neighbors-states [0 0 0 1 1 1 0 0 0]))))) )
 
 ((deftest east-west-neighbors-states-test
-   (testing "Filters to all neightbors (removes center, which is being updated)."
+   (testing "Filters to E and W neightbors."
      (is (= [1 1] (cell/east-west-neighbor-states [0 0 0 1 1 1 0 0 0]))))))
 
-((deftest self-ref-fule-east-west-neighbors-states-test
-   (testing "Filters to all neightbors (removes center, which is being updated)."
-     (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
-           dimensions [2 2]
-           states [0 1]
-           world-state-init [[1 0]
-                             [0 1]]
-           world-init (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
-           ;; Generate a rule function, using only east and west neighbors
-           rule (cell/self-ref-rule-factory cell/east-west-neighbor-states)
-           world-next-state (cell/update-world world-init rule)]
-      ;;  (println world-next-state)
-       (is (= (vals (get world-next-state :cells)) [1 1 
-                                                    1 1]))))))
+((deftest north-south-neighbors-states-test
+   (testing "Filters to N and S neightbors."
+     (is (= [1 1] (cell/north-south-neighbor-states [0 1 0 0 0 0 0 1 0]))))))
+
+((deftest rule-key-location-test-1
+   (testing "Context of the test assertions"
+     (is (= [1 2] (cell/rule-key-location 5 [3 3]))))))
+
+
+((deftest rule-key-location-test-2
+   (testing "Context of the test assertions"
+     (is (= [0 0] (cell/rule-key-location 0 [3 3]))))))
+
+;; ((deftest self-ref-rule-east-west-neighbors-states-test-case-1
+;;    (testing "Filters to all neighbors (removes center, which is being updated)."
+;;      (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
+;;            dimensions [2 2]
+;;            states [0 1]
+;;            world-state-init [[1 0]
+;;                              [0 1]]
+;;            world-init (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
+;;            ;; Generate a rule function, using only east and west neighbors
+;;            rule (cell/self-ref-rule-factory cell/east-west-neighbor-states)
+;;            world-next-state (cell/update-world world-init rule)]
+;;       ;;  (println world-next-state)
+;;        (is (= (vals (get world-next-state :cells)) '(1 1 
+;;                                                      1 1)))))))
+
+;; ((deftest self-ref-rule-east-west-neighbors-states-test-case-2
+;;    (testing "Filters to all neighbors (removes center, which is being updated)."
+;;      (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
+;;            dimensions [2 2]
+;;            states [0 1]
+;;            world-state-init [[1 1]
+;;                              [0 0]]
+;;            world-init (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
+;;            ;; Generate a rule function, using only east and west neighbors
+;;            rule (cell/self-ref-rule-factory cell/east-west-neighbor-states)
+;;            world-next-state (cell/update-world world-init rule)]
+;;       ;;  (println world-next-state)
+;;        (is (= (vals (get world-next-state :cells)) '(0 0 1 1)))))))
+
+;; ((deftest self-ref-rule-north-south-neighbors-states-test-case-1
+;;    (testing "Filters to all neighbors (removes center, which is being updated)."
+;;      (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
+;;            dimensions [2 2]
+;;            states [0 1]
+;;            world-state-init [[1 0]
+;;                              [0 1]]
+;;            world-init (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
+;;            ;; Generate a rule function, using only east and west neighbors
+;;            rule (cell/self-ref-rule-factory cell/north-south-neighbor-states)
+;;            world-next-state (cell/update-world world-init rule)]
+;;       ;;  (println world-next-state)
+;;        (is (= (vals (get world-next-state :cells)) '(1 1
+;;                                                        1 1)))))))
+
+;; ((deftest self-ref-rule-east-west-neighbors-states-test-case-2
+;;    (testing "Filters to all neighbors (removes center, which is being updated)."
+;;      (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
+;;            dimensions [2 2]
+;;            states [0 1]
+;;            world-state-init [[1 1]
+;;                              [0 0]]
+;;            world-init (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
+;;            ;; Generate a rule function, using only east and west neighbors
+;;            rule (cell/self-ref-rule-factory cell/north-south-neighbor-states)
+;;            world-next-state (cell/update-world world-init rule)]
+;;       ;;  (println world-next-state)
+;;        (is (= (vals (get world-next-state :cells)) '(1 1 0 0)))))))

--- a/test/orb/cell_test.clj
+++ b/test/orb/cell_test.clj
@@ -76,4 +76,23 @@
 
 ((deftest all-neighbors-states-test
       (testing "Filters to all neightbors (removes center, which is being updated)."
-        (is (= [1 0 0 0 0 0 0 1] (cell/all-neighbors-states [1 0 0 0 1 0 0 0 1]))))) )
+        (is (= [0 0 0 1 1 0 0 0] (cell/all-neighbors-states [0 0 0 1 1 1 0 0 0]))))) )
+
+((deftest east-west-neighbors-states-test
+   (testing "Filters to all neightbors (removes center, which is being updated)."
+     (is (= [1 1] (cell/east-west-neighbor-states [0 0 0 1 1 1 0 0 0]))))))
+
+((deftest self-ref-fule-east-west-neighbors-states-test
+   (testing "Filters to all neightbors (removes center, which is being updated)."
+     (let [;; Generate a 256 cell world to represent all values of 8 bit string (from neighbor states).
+           dimensions [2 2]
+           states [0 1]
+           world-state-init [[1 0]
+                             [0 1]]
+           world-init (cell/make-world dimensions states (fn [[x y]] (nth (nth world-state-init y) x)))
+           ;; Generate a rule function, using only east and west neighbors
+           rule (cell/self-ref-rule-factory cell/east-west-neighbor-states)
+           world-next-state (cell/update-world world-init rule)]
+      ;;  (println world-next-state)
+       (is (= (vals (get world-next-state :cells)) [1 1 
+                                                    1 1]))))))

--- a/test/orb/cell_test.clj
+++ b/test/orb/cell_test.clj
@@ -87,12 +87,12 @@
      (is (= [1 1] (cell/north-south-neighbor-states [0 1 0 0 0 0 0 1 0]))))))
 
 ((deftest rule-key-location-test-1
-   (testing "Context of the test assertions"
+   (testing "Maps rule key (index) to cells grid location ([x y])"
      (is (= [1 2] (cell/rule-key-location 5 [3 3]))))))
 
 
 ((deftest rule-key-location-test-2
-   (testing "Context of the test assertions"
+   (testing "Maps rule key (index) to cells grid location ([x y])"
      (is (= [0 0] (cell/rule-key-location 0 [3 3]))))))
 
 ;; ((deftest self-ref-rule-east-west-neighbors-states-test-case-1


### PR DESCRIPTION
Fixes a few bugs which broke our testing yesterday:

- In `decimal-rule-key-to-location`, `mod` and `quot` operations should be performed on the `rows` coordinate (was performed on `cols`).
- When setting up initial state, the binary string must be built starting at the NE neighbor, working toward the SW corner.  For instance, for a cell to be mapped to row key 9 (0 0 0 0 0 1 0 0 1), the cell (centered) and it's neighbors should be arranged like:

0 0 0
0 0 0
0 1 1

Not 

0 0 0 
0 0 1 
0 0 1